### PR TITLE
Carray ext 1685 26

### DIFF
--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -1173,7 +1173,7 @@ cdef class carray:
                 raise NotImplementedError(
                     "creating carrays from scalar objects is not supported")
         try:
-            self.expectedlen = expectedlen
+            self.expectedlen = <long> expectedlen
         except OverflowError:
             raise OverflowError(
                 "The size cannot be larger than 2**31 on 32-bit platforms")
@@ -1544,7 +1544,7 @@ cdef class carray:
         atomsize = self.atomsize
         chunks = self.chunks
         leftover = self.leftover
-        bsize = nitems * atomsize
+        bsize = <int> nitems * atomsize
         cbytes = 0
 
         # Check if items belong to the last chunk
@@ -1648,7 +1648,7 @@ cdef class carray:
             if newshape.count(-1) > 1:
                 raise ValueError("only one shape dimension can be -1")
             pos = newshape.index(-1)
-            osize = np.prod(newshape[:pos] + newshape[pos + 1:])
+            osize = <int> np.prod(newshape[:pos] + newshape[pos + 1:])
             if isize == 0:
                 newshape = newshape[:pos] + (0,) + newshape[pos + 1:]
             else:
@@ -2034,8 +2034,8 @@ cdef class carray:
         nchunks = <npy_intp> cython.cdiv(self._nbytes, self._chunksize)
         if self.leftover > 0:
             nchunks += 1
-        first_chunk = <npy_intp> cython.cdiv(start, self.chunklen)
-        last_chunk = <npy_intp> cython.cdiv(stop, self.chunklen) + 1
+        first_chunk = <npy_intp> <int> cython.cdiv(start, self.chunklen)
+        last_chunk = <npy_intp> <int> cython.cdiv(stop, self.chunklen) + 1
         last_chunk = min(last_chunk, nchunks)
         for nchunk from first_chunk <= nchunk < last_chunk:
             # Compute start & stop for each block
@@ -2200,8 +2200,8 @@ cdef class carray:
         nchunks = <npy_intp> cython.cdiv(self._nbytes, self._chunksize)
         if self.leftover > 0:
             nchunks += 1
-        first_chunk = <npy_intp> cython.cdiv(start, self.chunklen)
-        last_chunk = <npy_intp> cython.cdiv(stop, self.chunklen) + 1
+        first_chunk = <npy_intp> <int> cython.cdiv(start, self.chunklen)
+        last_chunk = <npy_intp> <int> cython.cdiv(stop, self.chunklen) + 1
         last_chunk = min(last_chunk, nchunks)
         for nchunk from first_chunk <= nchunk < last_chunk:
             # Compute start & stop for each block

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -1682,7 +1682,7 @@ cdef class carray:
                        expectedlen=newlen,
                        rootdir=rootdir, mode='w')
         if newlen < ilen:
-            rsize = isize / newlen
+            rsize = isize // newlen
             for i from 0 <= i < newlen:
                 out.append(
                     self[i * rsize:(i + 1) * rsize].reshape(newdtype.shape))

--- a/bcolz/carray_ext.pyx
+++ b/bcolz/carray_ext.pyx
@@ -589,7 +589,7 @@ cdef class chunk:
 
     def __repr__(self):
         """Represent the chunk as an string, with additional info."""
-        cratio = self.nbytes / float(self.cbytes)
+        cratio = self.nbytes // float(self.cbytes)
         fullrepr = "chunk(%s)  nbytes: %d; cbytes: %d; ratio: %.2f\n%r" % \
                    (self.dtype, self.nbytes, self.cbytes, cratio, str(self))
         return fullrepr
@@ -1652,7 +1652,7 @@ cdef class carray:
             if isize == 0:
                 newshape = newshape[:pos] + (0,) + newshape[pos + 1:]
             else:
-                newshape = newshape[:pos] + (isize / osize,) + newshape[
+                newshape = newshape[:pos] + (isize // osize,) + newshape[
                                                                pos + 1:]
             newsize = np.prod(newshape)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requires = [
     "setuptools>=45",
     "setuptools_scm[toml]>=6.2",
     "wheel",
-    "Cython>=0.22,<3.0",
+    "Cython>=0.22",
     "toml",
     # see: https://github.com/scipy/oldest-supported-numpy/blob/master/setup.cfg
     "oldest-supported-numpy"

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ BLOSC_DIR = os.environ.get('BLOSC_DIR', '')
 inc_dirs = ['bcolz']
 lib_dirs = []
 libs = []
-def_macros = []
+def_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
 sources = ['bcolz/carray_ext.pyx']
 
 # Handle --blosc=[PATH] --lflags=[FLAGS] --cflags=[FLAGS]


### PR DESCRIPTION
fix issue https://github.com/stefan-jansen/bcolz-zipline/issues/40

this PR applies change in carray_ext.pyx file and removes Cython < 3.0 restriction.