### PR TITLE
Workaround for importing of Numpy internal APIs.

### DIFF
--- a/bcolz/arrayprint.py
+++ b/bcolz/arrayprint.py
@@ -25,10 +25,12 @@ from .py2help import xrange
 # Workaround using Numy's internal API for compatibilty with both numpy<2 and numpy>=2.
 try:
     from numpy.core import numerictypes as _nt
+    import numpy.core.numeric as _nc
     from numpy.core.multiarray import format_longfloat
     from numpy.core.fromnumeric import ravel
 except ImportError:
     from numpy._core import numerictypes as _nt
+    import numpy._core.numeric as _nc
     from numpy._core.multiarray import format_longfloat
     from numpy._core.fromnumeric import ravel
 
@@ -576,8 +578,6 @@ class FloatFormat(object):
             pass
 
     def fillFormat(self, data):
-        import numpy._core.numeric as _nc
-
         errstate = _nc.seterr(all='ignore')
         try:
             special = isnan(data) | isinf(data)

--- a/bcolz/arrayprint.py
+++ b/bcolz/arrayprint.py
@@ -19,11 +19,18 @@ import sys
 from pkg_resources import parse_version
 
 import numpy
-from numpy._core import numerictypes as _nt
 from numpy import maximum, minimum, absolute, not_equal, isnan, isinf
-from numpy._core.multiarray import format_longfloat
-from numpy._core.fromnumeric import ravel
 from .py2help import xrange
+
+# Workaround using Numy's internal API for compatibilty with both numpy<2 and numpy>=2.
+try:
+    from numpy.core import numerictypes as _nt
+    from numpy.core.multiarray import format_longfloat
+    from numpy.core.fromnumeric import ravel
+except ImportError:
+    from numpy._core import numerictypes as _nt
+    from numpy._core.multiarray import format_longfloat
+    from numpy._core.fromnumeric import ravel
 
 
 try:

--- a/bcolz/tests/test_carray.py
+++ b/bcolz/tests/test_carray.py
@@ -67,9 +67,9 @@ class initTest(TestCase):
             'a': np.arange(3),
             'b': np.arange(3)[::-1]
         })
-        ca = carray(df, dtype=np.dtype(np.float))
+        ca = carray(df, dtype=np.dtype(float))
         assert_array_equal(df, ca)
-        self.assertEqual(ca.dtype, np.dtype(np.float),
+        self.assertEqual(ca.dtype, np.dtype(float),
                          msg='carray has been created with invalid dtype')
 
     def test_dtype_None(self):


### PR DESCRIPTION
A hack to (at least temporarily) deal with using Numpy internal API and being compatible with both `numpy<2` and `numpy>=2`.

Fix https://github.com/stefan-jansen/bcolz-zipline/issues/61.