### PR TITLE
Fix raw string for regex in ctable.py

### DIFF
--- a/bcolz/ctable.py
+++ b/bcolz/ctable.py
@@ -27,7 +27,7 @@ _inttypes += (np.integer,)
 ROOTDIRS = '__rootdirs__'
 
 re_ident = re.compile(r"^[^\d\W]\w*$", re.UNICODE)
-re_str_split = re.compile("^\s+|\s*,\s*|\s+$")
+re_str_split = re.compile(r"^\s+|\s*,\s*|\s+$")
 
 
 def validate_names(columns, keyword='names'):


### PR DESCRIPTION
Fixes this warning (and presumably the case involved):

```
.venv/lib/python3.12/site-packages/bcolz/ctable.py:30: SyntaxWarning: invalid escape sequence '\s'
  re_str_split = re.compile("^\s+|\s*,\s*|\s+$")
```