### PR TITLE
pin cython version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requires = [
     "setuptools>=45",
     "setuptools_scm[toml]>=6.2",
     "wheel",
-    "Cython>=0.22",
+    'Cython>=0.22,<3.1',
     "toml",
     # Force numpy higher than 2.0rc1, so that built wheels are compatible
     # with both numpy 1 and 2


### PR DESCRIPTION
pin cython version `'Cython>=0.22,<3.1',` to avoid errors while creating wheels.

required by https://github.com/stefan-jansen/zipline-reloaded/pull/281